### PR TITLE
[fix]:make resume bake case-insensitive (main has Resume.md; Linux fs…

### DIFF
--- a/scripts/bake-master.mjs
+++ b/scripts/bake-master.mjs
@@ -1,11 +1,16 @@
-// Bake content/resume.md into an importable JSON module so the resume API routes
+// Bake the resume markdown into an importable JSON module so the resume API routes
 // don't read the filesystem at runtime (serverless functions don't bundle repo files,
-// and Next 16 + Turbopack file-tracing is unreliable). Runs at prebuild + committable.
+// and Next 16 + Turbopack file-tracing is unreliable). Runs at prebuild.
+// Case-insensitive lookup: `update` has content/resume.md, `main` has content/Resume.md,
+// and Linux (Netlify) is case-sensitive.
 import fs from "fs";
 import path from "path";
 
-const src = path.join(process.cwd(), "content/resume.md");
+const contentDir = path.join(process.cwd(), "content");
+const file = fs.readdirSync(contentDir).find((f) => /^resume\.md$/i.test(f));
+if (!file) throw new Error("bake-master: no resume*.md found in content/");
+
+const text = fs.readFileSync(path.join(contentDir, file), "utf8");
 const out = path.join(process.cwd(), "server/ai/resumeMaster.json");
-const text = fs.readFileSync(src, "utf8");
 fs.writeFileSync(out, JSON.stringify({ text }));
-console.log(`baked ${text.length} chars from content/resume.md -> ${out}`);
+console.log(`baked ${text.length} chars from content/${file} -> ${out}`);


### PR DESCRIPTION
resume is case-sensitive)

Production (main) tracks content/Resume.md while update tracks content/resume.md. bake-master.mjs now finds resume*.md regardless of case, so the prebuild step works on both branches / on Netlify's case-sensitive filesystem.